### PR TITLE
Terraform hotfix

### DIFF
--- a/05/src/main.tf
+++ b/05/src/main.tf
@@ -16,7 +16,7 @@ module "vpc-net" {
 }
 
 module "example-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   for_each = toset(var.projects)
 
   env_name       = var.vms_common_options.env_name

--- a/05/src/modules/vpc_dev/providers.tf
+++ b/05/src/modules/vpc_dev/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~>0.130.0"
     }
   }
   required_version = "~>1.8.4"

--- a/05/src/modules/vpc_dev/providers.tf
+++ b/05/src/modules/vpc_dev/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
-      version = "~>0.130.0"
+      version = "~>0.132.0"
     }
   }
   required_version = "~>1.8.4"

--- a/05/src/providers.tf
+++ b/05/src/providers.tf
@@ -2,8 +2,14 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~>0.130.0"
+    }
+    template = {
+      source = "hashicorp/template"
+      version = "~>2.2.0"
     }
   }
+
   required_version = "~>1.8.4"
 
   backend "s3" {

--- a/05/src/providers.tf
+++ b/05/src/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
-      version = "~>0.130.0"
+      version = "~>0.132.0"
     }
     template = {
       source = "hashicorp/template"

--- a/05/src/variables.tf
+++ b/05/src/variables.tf
@@ -33,12 +33,6 @@ variable "vpc_name" {
 
 ###common vars
 
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
-
 variable "vms_ssh_user" {
   type        = string
   default     = "ubuntu"
@@ -77,46 +71,9 @@ variable "vms_common_options" {
   description = "Parameters common to all VMs"
 }
 
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
 variable "projects" {
   type = list(string)
   default = ["marketing", "analytics"]
   description = "Project names to create VMs for."
 }
 
-variable "test_ip" {
-  type = string
-  default = "192.168.0.1"
-  #default = "1920.1680.0.1"
-  description="ip-адрес"
-  validation {
-    condition = can(cidrnetmask("${var.test_ip}/32"))
-    error_message = "Invalid IP address provided."
-  }
-}
-
-variable "test_cidr_list" {
-  type = list(string)
-  default =  ["192.168.0.1", "1.1.1.1", "127.0.0.1"]
-  #default = ["192.168.0.1", "1.1.1.1", "1270.0.0.1"]
-  description="список ip-адресов"
-  validation {
-    condition = alltrue([
-      for addr in var.test_cidr_list: can(cidrnetmask("${addr}/32"))
-    ])
-    error_message = "Invalid IP set provided."
-  }
-}


### PR DESCRIPTION
Результат проверки TFLINT:

```
alexsys@netol-tf-01:/home/projects/netology-devops/homeworks-v2/netology-tf/05/src$ tflint --recursive
7 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 19:
  19:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 49:
  49: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on modules/vpc_dev/providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "vms_ssh_root_key" is declared but not used (terraform_unused_declarations)

  on variables.tf line 36:
  36: variable "vms_ssh_root_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 81:
  81: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 88:
  88: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

```

Результат checkov:

```

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.293 

terraform scan results:

Passed checks: 0, Failed checks: 4, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: example-vm["analytics"]
	File: /main.tf:18-47
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

		18 | module "example-vm" {
		19 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		20 |   for_each = toset(var.projects)
		21 | 
		22 |   env_name       = var.vms_common_options.env_name
		23 |   network_id     = module.vpc-net.vpc_subnet.network_id
		24 |   subnet_zones   = var.vms_common_options.subnet_zones
		25 |   #subnet_ids     = [yandex_vpc_subnet.develop.id]
		26 |   subnet_ids     = [module.vpc-net.vpc_subnet.id]
		27 |   instance_name  = "${var.vms_common_options.instance_name}-${each.key}"
		28 |   instance_count = var.vms_common_options.instance_count
		29 |   image_family   = var.vms_common_options.image_family
		30 |   public_ip      = var.vms_common_options.public_ip
		31 |   #РґРѕР±Р°РІРёРј, С‡С‚РѕР±С‹ РЅРµ С‚СЂР°С‚РёС‚СЊ РґРµРЅРµРі
		32 |   platform = var.vms_common_options.platform
		33 |   instance_core_fraction = var.vms_common_options.instance_core_fraction
		34 |   preemptible = var.vms_common_options.preemptible
		35 |   boot_disk_size = var.vms_common_options.boot_disk_size
		36 |   instance_memory = var.vms_common_options.instance_memory
		37 | 
		38 |   labels = {
		39 |     project = each.value
		40 |   }
		41 | 
		42 |   metadata = {
		43 |     user-data          = data.template_file.cloudinit.rendered
		44 |     serial-port-enable = var.vms_common_options.meta_serial-port-enable
		45 |   }
		46 | 
		47 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: example-vm["analytics"]
	File: /main.tf:18-47
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag

		18 | module "example-vm" {
		19 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		20 |   for_each = toset(var.projects)
		21 | 
		22 |   env_name       = var.vms_common_options.env_name
		23 |   network_id     = module.vpc-net.vpc_subnet.network_id
		24 |   subnet_zones   = var.vms_common_options.subnet_zones
		25 |   #subnet_ids     = [yandex_vpc_subnet.develop.id]
		26 |   subnet_ids     = [module.vpc-net.vpc_subnet.id]
		27 |   instance_name  = "${var.vms_common_options.instance_name}-${each.key}"
		28 |   instance_count = var.vms_common_options.instance_count
		29 |   image_family   = var.vms_common_options.image_family
		30 |   public_ip      = var.vms_common_options.public_ip
		31 |   #РґРѕР±Р°РІРёРј, С‡С‚РѕР±С‹ РЅРµ С‚СЂР°С‚РёС‚СЊ РґРµРЅРµРі
		32 |   platform = var.vms_common_options.platform
		33 |   instance_core_fraction = var.vms_common_options.instance_core_fraction
		34 |   preemptible = var.vms_common_options.preemptible
		35 |   boot_disk_size = var.vms_common_options.boot_disk_size
		36 |   instance_memory = var.vms_common_options.instance_memory
		37 | 
		38 |   labels = {
		39 |     project = each.value
		40 |   }
		41 | 
		42 |   metadata = {
		43 |     user-data          = data.template_file.cloudinit.rendered
		44 |     serial-port-enable = var.vms_common_options.meta_serial-port-enable
		45 |   }
		46 | 
		47 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: example-vm["marketing"]
	File: /main.tf:18-47
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

		18 | module "example-vm" {
		19 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		20 |   for_each = toset(var.projects)
		21 | 
		22 |   env_name       = var.vms_common_options.env_name
		23 |   network_id     = module.vpc-net.vpc_subnet.network_id
		24 |   subnet_zones   = var.vms_common_options.subnet_zones
		25 |   #subnet_ids     = [yandex_vpc_subnet.develop.id]
		26 |   subnet_ids     = [module.vpc-net.vpc_subnet.id]
		27 |   instance_name  = "${var.vms_common_options.instance_name}-${each.key}"
		28 |   instance_count = var.vms_common_options.instance_count
		29 |   image_family   = var.vms_common_options.image_family
		30 |   public_ip      = var.vms_common_options.public_ip
		31 |   #РґРѕР±Р°РІРёРј, С‡С‚РѕР±С‹ РЅРµ С‚СЂР°С‚РёС‚СЊ РґРµРЅРµРі
		32 |   platform = var.vms_common_options.platform
		33 |   instance_core_fraction = var.vms_common_options.instance_core_fraction
		34 |   preemptible = var.vms_common_options.preemptible
		35 |   boot_disk_size = var.vms_common_options.boot_disk_size
		36 |   instance_memory = var.vms_common_options.instance_memory
		37 | 
		38 |   labels = {
		39 |     project = each.value
		40 |   }
		41 | 
		42 |   metadata = {
		43 |     user-data          = data.template_file.cloudinit.rendered
		44 |     serial-port-enable = var.vms_common_options.meta_serial-port-enable
		45 |   }
		46 | 
		47 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: example-vm["marketing"]
	File: /main.tf:18-47
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag

		18 | module "example-vm" {
		19 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		20 |   for_each = toset(var.projects)
		21 | 
		22 |   env_name       = var.vms_common_options.env_name
		23 |   network_id     = module.vpc-net.vpc_subnet.network_id
		24 |   subnet_zones   = var.vms_common_options.subnet_zones
		25 |   #subnet_ids     = [yandex_vpc_subnet.develop.id]
		26 |   subnet_ids     = [module.vpc-net.vpc_subnet.id]
		27 |   instance_name  = "${var.vms_common_options.instance_name}-${each.key}"
		28 |   instance_count = var.vms_common_options.instance_count
		29 |   image_family   = var.vms_common_options.image_family
		30 |   public_ip      = var.vms_common_options.public_ip
		31 |   #РґРѕР±Р°РІРёРј, С‡С‚РѕР±С‹ РЅРµ С‚СЂР°С‚РёС‚СЊ РґРµРЅРµРі
		32 |   platform = var.vms_common_options.platform
		33 |   instance_core_fraction = var.vms_common_options.instance_core_fraction
		34 |   preemptible = var.vms_common_options.preemptible
		35 |   boot_disk_size = var.vms_common_options.boot_disk_size
		36 |   instance_memory = var.vms_common_options.instance_memory
		37 | 
		38 |   labels = {
		39 |     project = each.value
		40 |   }
		41 | 
		42 |   metadata = {
		43 |     user-data          = data.template_file.cloudinit.rendered
		44 |     serial-port-enable = var.vms_common_options.meta_serial-port-enable
		45 |   }
		46 | 
		47 | }
```

После исправления `tf plan` предлагает сделать init, т.к. изменилась версия удалённого модуля:
```
alexsys@netol-tf-01:/home/projects/netology-devops/homeworks-v2/netology-tf/05/src$ terraform plan
Acquiring state lock. This may take a few moments...
╷
│ Error: Module source has changed
│
│   on main.tf line 19, in module "example-vm":
│   19:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
│
│ The source address was changed since this module was installed. Run "terraform init" to install all modules required by this configuration.

```
После инициализации в плане изменений нет.
